### PR TITLE
same rate limits apply to consumptions

### DIFF
--- a/98_EaseeWallbox.pm
+++ b/98_EaseeWallbox.pm
@@ -555,13 +555,13 @@ sub RefreshData {
     WriteToCloudAPI( $hash, 'getChargerSite',            'GET' );
     WriteToCloudAPI( $hash, 'getChargerState',           'GET' );
     WriteToCloudAPI( $hash, 'getChargerConfiguration',   'GET' );
-    WriteToCloudAPI( $hash, 'getMonthlyEnergyConsumption', 'GET' );
-    WriteToCloudAPI( $hash, 'getDailyEnergyConsumption',   'GET' );
     WriteToCloudAPI( $hash, 'getDynamicCurrent',         'GET' );
 
     #Rate Limit. Just run every 6 minutes
     if ($hash->{CURRENT_SESSION_REFRESH} + 360 < gettimeofday()) {
         WriteToCloudAPI( $hash, 'getCurrentSession',         'GET' );
+        WriteToCloudAPI( $hash, 'getMonthlyEnergyConsumption', 'GET' );
+        WriteToCloudAPI( $hash, 'getDailyEnergyConsumption',   'GET' );
     }
 
     return;    # immer mit einem return eine funktion beenden


### PR DESCRIPTION
apply the 6 minute rate limit to all consuption endpoints.
According to the docu and the user feedback it should apply to them as well.
Couldn't confirm this in my setup but maybe because my data got cached as I had no car connected