### PR TITLE
Handle parameter count errors in EaseeWallbox

### DIFF
--- a/98_EaseeWallbox.pm
+++ b/98_EaseeWallbox.pm
@@ -286,8 +286,8 @@ sub Define {
 
     # Check parameter(s) - Must be min 4 in total (counts strings not purly parameter, interval is optional)
     if ( int(@param) < 4 ) {
-        $errmsg = return
-                "syntax error: define <name> EaseeWallbox <username> <password> [interval] [chargerID]";
+        $errmsg =
+          "syntax error: define <name> EaseeWallbox <username> <password> [interval] [chargerID]";
         Log3 $name, 1, "EaseeWallbox $name: " . $errmsg;
         return $errmsg;
     }


### PR DESCRIPTION
## Summary
- Avoid returning before logging by separating error assignment and return when parameters are missing

## Testing
- `perl -c 98_EaseeWallbox.pm` *(fails: Can't locate HttpUtils.pm in @INC)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.0.3 8080])*

------
https://chatgpt.com/codex/tasks/task_b_6897a7429d948332a3f9b7aef0d48d6a