### PR TITLE
Remove stray module terminator

### DIFF
--- a/98_EaseeWallbox.pm
+++ b/98_EaseeWallbox.pm
@@ -1446,7 +1446,6 @@ sub _decrypt {
     return $decoded;
 }
 
-1;
 
 sub _transcodeDate {
     my $datestr = shift;


### PR DESCRIPTION
## Summary
- remove an extraneous `1;` that appeared before `_transcodeDate` in `98_EaseeWallbox.pm`

## Testing
- `perl -c 98_EaseeWallbox.pm` *(fails: Can't locate HttpUtils.pm)*
- `apt-get update` *(fails: repository InRelease files not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6897a75cb3388332a52b359eac397011