### PR TITLE
Remove unused expertMode attribute

### DIFF
--- a/98_EaseeWallbox.pm
+++ b/98_EaseeWallbox.pm
@@ -263,8 +263,7 @@ sub Initialize {
     $hash->{WriteFn} = \&Write;
 
     $hash->{AttrList} =
-        'expertMode:yes,no '
-      . 'interval '
+        'interval '
       . 'SmartCharging:true,false '
       . $readingFnAttributes;
 
@@ -1533,7 +1532,6 @@ sub NumericToBoolean {
 <b>Attributes</b>
 <ul>
   <li>interval - polling interval in seconds (default 60)</li>
-  <li>expertMode&nbsp;yes|no</li>
   <li>SmartCharging&nbsp;true|false - automatically enable smart charging</li>
 </ul>
 <br>


### PR DESCRIPTION
## Summary
- remove unused expertMode attribute
- drop expertMode from module documentation

## Testing
- `perl -c 98_EaseeWallbox.pm` *(fails: Can't locate HttpUtils.pm)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_6897b6efc3c48332aa2ce5a12fe505b5